### PR TITLE
DrupalPage: Only persist context on mount for same url

### DIFF
--- a/packages/hn-react/src/components/DrupalPage.js
+++ b/packages/hn-react/src/components/DrupalPage.js
@@ -23,8 +23,12 @@ class DrupalPage extends Component {
    * multiple renders.
    */
   async asyncBootstrap() {
+    const drupalPage = await this.loadData(this.props);
     this.context.hnContext.state = {
-      drupalPage: await this.loadData(this.props),
+      drupalPage: {
+        componentState: drupalPage,
+        dataUrl: drupalPage.dataUrl,
+      },
       entities: [],
     };
     return true;
@@ -34,7 +38,10 @@ class DrupalPage extends Component {
    * The first time this element is rendered, we always make sure the component and the Drupal page is loaded.
    */
   componentWillMount() {
-    const state = getNested(() => this.context.hnContext.state.drupalPage);
+    const state = getNested(() => {
+      const drupalPage = this.context.hnContext.state.drupalPage;
+      return drupalPage.dataUrl === this.props.url && drupalPage.componentState;
+    });
     if (state) {
       this.setState(state);
     } else {


### PR DESCRIPTION
When HN is unmounted after url1 is fetched, and remounted with url2,
the state of url1 will be displayed instead of the correct url2. This
fix will check onMount whether the state in context actually belongs to
the path you're currently on.

Closes #23