### PR TITLE
Use node 8 and 9 for Travis CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
-node_js: node
+node_js:
+  - 9
+  - 8
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
-node_js:
-  - 9
-  - 8
+node_js: 9
 
 notifications:
   email: false


### PR DESCRIPTION
Node 10 (that recently came out) builds are currently failing. Let's try testing on node 8 and 9.