### PR TITLE
Disable allowSyntheticDefaultImports

### DIFF
--- a/packages/hn-react/src/components/DrupalPage.test.tsx
+++ b/packages/hn-react/src/components/DrupalPage.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import renderer from 'react-test-renderer';
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
 import site from '../utils/site';
 import { asyncMapper, mapper, uuid, uuid2 } from '../utils/tests';
 import waitForHnData from '../utils/waitForHnData';

--- a/packages/hn-react/src/components/DrupalPage.tsx
+++ b/packages/hn-react/src/components/DrupalPage.tsx
@@ -1,13 +1,14 @@
-import getNested from 'get-nested';
 import { Site } from 'hn';
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
 import { SiteConsumer } from '../context/site';
 import EntityMapper, {
   EntityMapper as InnerEntityMapper,
 } from './EntityMapper';
 
-class DrupalPage extends Component<
+const getNested = require('get-nested'); // tslint:disable-line:no-var-requires
+
+class DrupalPage extends React.Component<
   DrupalPageProps & { site: Site },
   DrupalPageState
 > {

--- a/packages/hn-react/src/components/EntityListMapper.test.tsx
+++ b/packages/hn-react/src/components/EntityListMapper.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import renderer from 'react-test-renderer';
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
 import site from '../utils/site';
 import { asyncMapper, mapper, uuid } from '../utils/tests';
 import waitForHnData from '../utils/waitForHnData';

--- a/packages/hn-react/src/components/EntityListMapper.tsx
+++ b/packages/hn-react/src/components/EntityListMapper.tsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
 import EntityMapper, { EntityMapperPropsMapper } from './EntityMapper';
 
 const EntityListMapper: React.StatelessComponent<EntityListMapperProps> = ({
@@ -10,7 +10,7 @@ const EntityListMapper: React.StatelessComponent<EntityListMapperProps> = ({
   asyncMapper,
 }: any): any =>
   entities.map((ref, index) => {
-    const EntityWrapper = entityWrapper || Fragment;
+    const EntityWrapper = entityWrapper || React.Fragment;
     const uuid = isEntityReferenceField(ref) ? ref.target_uuid : ref;
 
     return (

--- a/packages/hn-react/src/components/EntityMapper.test.tsx
+++ b/packages/hn-react/src/components/EntityMapper.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import renderer from 'react-test-renderer';
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
 import site from '../utils/site';
 import {
   asyncMapper,

--- a/packages/hn-react/src/components/EntityMapper.tsx
+++ b/packages/hn-react/src/components/EntityMapper.tsx
@@ -1,8 +1,9 @@
-import getNested from 'get-nested';
 import { Site } from 'hn';
-import PropTypes from 'prop-types';
-import React, { ReactType } from 'react';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
 import { SiteConsumer } from '../context/site';
+
+const getNested = require('get-nested'); // tslint:disable-line:no-var-requires
 
 export class EntityMapper extends React.Component<
   EntityMapperProps & { site: Site },
@@ -233,14 +234,14 @@ export class EntityMapper extends React.Component<
 }
 
 export interface ObjectMapper {
-  [uuid: string]: ReactType;
+  [uuid: string]: React.ReactType;
 }
 export interface ObjectMapperAsync {
-  [uuid: string]: () => Promise<ReactType>;
+  [uuid: string]: () => Promise<React.ReactType>;
 }
 
-export type functionMapper = (entity: object) => ReactType;
-export type functionMapperAsync = (entity: object) => Promise<ReactType>;
+export type functionMapper = (entity: object) => React.ReactType;
+export type functionMapperAsync = (entity: object) => Promise<React.ReactType>;
 
 export type mapperType =
   | ObjectMapper

--- a/packages/hn-react/src/components/deprecated/Paragraph.test.tsx
+++ b/packages/hn-react/src/components/deprecated/Paragraph.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import renderer from 'react-test-renderer';
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
 import site from '../../utils/site';
 import { mapper, uuid } from '../../utils/tests';
 import waitForHnData from '../../utils/waitForHnData';

--- a/packages/hn-react/src/components/deprecated/Paragraph.tsx
+++ b/packages/hn-react/src/components/deprecated/Paragraph.tsx
@@ -1,7 +1,8 @@
-import PropTypes from 'prop-types';
-import React from 'react';
-import deprecate from 'util-deprecate';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
 import EntityMapper from '../EntityMapper';
+
+const deprecate = require('util-deprecate'); // tslint:disable-line:no-var-requires
 
 const Paragraph: React.StatelessComponent<ParagraphProps> = ({
   mapper,

--- a/packages/hn-react/src/components/deprecated/Paragraphs.test.tsx
+++ b/packages/hn-react/src/components/deprecated/Paragraphs.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import renderer from 'react-test-renderer';
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
 import site from '../../utils/site';
 import { mapper, uuid } from '../../utils/tests';
 import waitForHnData from '../../utils/waitForHnData';

--- a/packages/hn-react/src/components/deprecated/Paragraphs.tsx
+++ b/packages/hn-react/src/components/deprecated/Paragraphs.tsx
@@ -1,7 +1,8 @@
-import PropTypes from 'prop-types';
-import React from 'react';
-import deprecate from 'util-deprecate';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
 import EntityListMapper from '../EntityListMapper';
+
+const deprecate = require('util-deprecate'); // tslint:disable-line:no-var-requires
 
 const Paragraphs: React.StatelessComponent<ParagraphsProps> = ({
   mapper,

--- a/packages/hn-react/src/context/site.test.tsx
+++ b/packages/hn-react/src/context/site.test.tsx
@@ -1,6 +1,6 @@
 import { Site } from 'hn';
-import React, { Component } from 'react';
-import renderer from 'react-test-renderer';
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
 import site from '../utils/site';
 import { SiteConsumer, SiteProvider, withSite } from './site';
 
@@ -76,7 +76,7 @@ describe('withSite', async () => {
     // @ts-ignore
     @withSite
     // @ts-ignore
-    class Consumer extends Component<{ site: Site }> {
+    class Consumer extends React.Component<{ site: Site }> {
       render() {
         renderedSite = this.props.site;
         return null;

--- a/packages/hn-react/src/context/site.tsx
+++ b/packages/hn-react/src/context/site.tsx
@@ -1,9 +1,9 @@
 import { Site } from 'hn';
-import React, { createContext, ReactNode } from 'react';
+import * as React from 'react';
 import globalSite from '../utils/site';
 
 // Create a new context.
-const { Provider, Consumer } = createContext(globalSite);
+const { Provider, Consumer } = React.createContext(globalSite);
 
 // The site provider is the same as the 'Provider', but changes 'site' to
 // 'value'.
@@ -12,7 +12,7 @@ export const SiteProvider = ({
   children,
 }: {
   site: Site;
-  children: ReactNode;
+  children: React.ReactNode;
 }) => <Provider value={site} children={children} />;
 
 // The consumer is exported as both Site and SiteConsumer. The SiteConsumer can

--- a/packages/hn-react/src/utils/tests/components/HOC.tsx
+++ b/packages/hn-react/src/utils/tests/components/HOC.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export default WrappedComponent => props => (
   <WrappedComponent {...props} hocProps />

--- a/packages/hn-react/src/utils/tests/components/MapperComponent.tsx
+++ b/packages/hn-react/src/utils/tests/components/MapperComponent.tsx
@@ -1,3 +1,3 @@
-import React from 'react';
+import * as React from 'react';
 
 export default props => <div className="MyCustomMapperComponent" {...props} />;

--- a/packages/hn-react/src/utils/tests/components/MapperComponentWithHOC.tsx
+++ b/packages/hn-react/src/utils/tests/components/MapperComponentWithHOC.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import HOC from './HOC';
 
 export default HOC(props => (

--- a/packages/hn-react/src/utils/tests/components/MapperComponentWithHOC2.tsx
+++ b/packages/hn-react/src/utils/tests/components/MapperComponentWithHOC2.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import HOC from './HOC';
 
 export default HOC(props => (

--- a/packages/hn-react/src/utils/tests/index.ts
+++ b/packages/hn-react/src/utils/tests/index.ts
@@ -68,5 +68,5 @@ export class SiteMock {
 }
 
 export function mockSite() {
-  return new SiteMock();
+  return { default: new SiteMock() };
 }

--- a/packages/hn-react/src/utils/waitForHnData.tsx
+++ b/packages/hn-react/src/utils/waitForHnData.tsx
@@ -1,6 +1,7 @@
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import asyncBootstrapper from 'react-async-bootstrapper';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
+
+const asyncBootstrapper = require('react-async-bootstrapper'); // tslint:disable-line:no-var-requires
 
 export default async function(children) {
   const context = {
@@ -10,7 +11,7 @@ export default async function(children) {
     },
   };
 
-  class DrupalPageContextProvider extends Component {
+  class DrupalPageContextProvider extends React.Component {
     static childContextTypes = {
       hnContext: PropTypes.object,
     };

--- a/packages/hn-react/types/react-async-bootstrapper/index.d.ts
+++ b/packages/hn-react/types/react-async-bootstrapper/index.d.ts
@@ -3,8 +3,10 @@ declare module 'react-async-bootstrapper' {
     componentWillUnmount?: boolean;
   }
 
-  export default function asyncBootstrapper(
+  function asyncBootstrapper(
     reactElement: JSX.Element,
     options: AsyncBootstrapperOptions,
   ): Promise<JSX.Element>;
+
+  export = asyncBootstrapper;
 }

--- a/packages/hn/src/Site.ts
+++ b/packages/hn/src/Site.ts
@@ -1,9 +1,9 @@
-import deepmerge from 'deepmerge';
-import getNested from 'get-nested';
+import * as deepmerge from 'deepmerge';
 import 'isomorphic-fetch';
 import { stringify } from 'query-string';
 import HnServerResponse, { HnData } from './HnServerResponse';
 import SiteInitializeParams from './SiteInitializeParams';
+const getNested = require('get-nested'); // tslint:disable-line:no-var-requires
 
 const propertiesToHydrate = ['tokensToVerify', 'user', 'data'];
 

--- a/packages/hn/src/__tests__/site.ts
+++ b/packages/hn/src/__tests__/site.ts
@@ -1,4 +1,4 @@
-import fetchMock from 'fetch-mock';
+import * as fetchMock from 'fetch-mock';
 import { parse } from 'url';
 import { Site } from '..';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "inlineSourceMap": false,
     "declaration": true,
     "jsx": "react",
-    "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
     "baseUrl": "./packages",
     "paths": {


### PR DESCRIPTION
When the allowSyntheticDefaultImports option of Typescript is set to _true_, the generated Typescript definitions can only be used on projects that also have this option set to _true_.

By disabling this option, it is usable in all Typescript projects.