### PR TITLE
fix(Site): import deepmerge with a require instead of a import. 

### DIFF
--- a/packages/hn/src/Site.ts
+++ b/packages/hn/src/Site.ts
@@ -1,9 +1,9 @@
-import * as deepmerge from 'deepmerge';
 import 'isomorphic-fetch';
 import { stringify } from 'query-string';
 import HnServerResponse, { HnData } from './HnServerResponse';
 import SiteInitializeParams from './SiteInitializeParams';
 const getNested = require('get-nested'); // tslint:disable-line:no-var-requires
+const deepmerge = require('deepmerge/dist/umd'); // tslint:disable-line:no-var-requires
 
 const propertiesToHydrate = ['tokensToVerify', 'user', 'data'];
 


### PR DESCRIPTION
Version 0.6.2 was breaking in Typescript projects due to a missing import/ package.
Using a require instead of the import fixes this problem.