### PR TITLE
fix(Drupal page): export the DrupalPage.assureData method

### DIFF
--- a/packages/hn-react/src/components/DrupalPage.tsx
+++ b/packages/hn-react/src/components/DrupalPage.tsx
@@ -216,4 +216,6 @@ const DrupalPageWrapper = React.forwardRef<DrupalPage, DrupalPageProps>(
   ),
 );
 
+export const assureData = DrupalPage.assureData;
+
 export default DrupalPageWrapper;

--- a/packages/hn-react/src/index.ts
+++ b/packages/hn-react/src/index.ts
@@ -1,6 +1,6 @@
 import Paragraph from './components/deprecated/Paragraph';
 import Paragraphs from './components/deprecated/Paragraphs';
-import DrupalPage from './components/DrupalPage';
+import DrupalPage, { assureData } from './components/DrupalPage';
 import EntityListMapper from './components/EntityListMapper';
 import EntityMapper from './components/EntityMapper';
 import {
@@ -26,4 +26,5 @@ export {
   SiteConsumer,
   InjectedSiteProps,
   withSite,
+  assureData,
 };


### PR DESCRIPTION
In a previous version of hn-react, I could import { DrupalPage } from 'hn-react', but since the
release implementing the React context API the DrupalPage isn't exported as such anymore. Instead,
we now find a React.forwardRef component without the previous existing static method. To solve
this, the DrupalPage.assureData() should be exported again, so it is easy to upgrade my projects to
the latest version of hn-react.

Closes #52