### PR TITLE
Replace all static methods with plain functions

### DIFF
--- a/packages/hn-react/src/components/EntityMapper.test.tsx
+++ b/packages/hn-react/src/components/EntityMapper.test.tsx
@@ -13,6 +13,7 @@ import waitForHnData from '../utils/waitForHnData';
 import EntityMapper, {
   EntityMapper as InnerEntityMapper,
   clearEntityCache,
+  assureComponent,
 } from './EntityMapper';
 
 jest.mock('../utils/site', () => {
@@ -164,9 +165,9 @@ describe('EntityMapper', async () => {
   });
 
   test('assure component with mapper not supporting bundle', async () => {
-    expect(
-      InnerEntityMapper.assureComponent({ site, uuid, asyncMapper: {} }),
-    ).resolves.toBe(undefined);
+    expect(assureComponent({ site, uuid, asyncMapper: {} })).resolves.toBe(
+      undefined,
+    );
   });
 
   async function setupPropsChange() {


### PR DESCRIPTION
Static methods can malfunction when bound to another context, then `this` becomes unavailable.

An example error when using the `assureComponent` function exported in the bundle:
```
TypeError: this.getComponentOrPromiseFromMapper is not a function
    at Object.getComponentOrPromiseFromMapper (node_modules/hn-react/src/components/EntityMapper.tsx:67:28)
    at next (node_modules/hn-react/src/components/EntityMapper.js:6:71)
    at new Promise (<anonymous>)
    at __awaiter (node_modules/hn-react/src/components/EntityMapper.js:2:12)
    at Object.__awaiter [as assureComponent] (node_modules/hn-react/src/components/EntityMapper.js:55:16)
```

By replacing the static methods with 'normal' plain functions, they don't use `this` anymore, and therefore changing context doesn't matter anymore.